### PR TITLE
Update metadata.ini

### DIFF
--- a/metadata.ini
+++ b/metadata.ini
@@ -11,7 +11,7 @@ license=This collection is released under CC0.
 license_file=license
 preview=preview/preview_migration.png,preview/preview_basic.png
 qgis_minimum_version=2.0
-qgis_maximum_version=2.99
+qgis_maximum_version=3.99
 
 [conveyor_belt_flows]
 author=Anita Graser
@@ -23,4 +23,4 @@ license=This collection is released under CC0.
 license_file=license
 preview=preview/preview.png
 qgis_minimum_version=2.0
-qgis_maximum_version=2.99
+qgis_maximum_version=3.99


### PR DESCRIPTION
I have tested the symbology proposed on QGIS 3.4 and it works.
Changing the QGIS maximum version make the plugin Resource Sharing able to use these resources on QGIS 3.